### PR TITLE
Require X11 explicitly

### DIFF
--- a/control/installation.xml
+++ b/control/installation.xml
@@ -30,10 +30,10 @@ textdomain="control"
                 <order config:type="integer">500</order>
                 <!-- the rest is overlaid over the feature sections and values. -->
                 <software>
-                  <default_patterns>base minimal_base</default_patterns>
+                  <default_patterns>base minimal_base x11</default_patterns>
                   <!-- the cdata trick produces an empty string in the data
                   instead of omitting the key entirely -->
-                  <optional_default_patterns>gnome-basic</optional_default_patterns>
+                  <optional_default_patterns>x11_enhanced gnome-basic</optional_default_patterns>
                 </software>
               </system_role>
             </system_roles>

--- a/package/system-role-server-default.changes
+++ b/package/system-role-server-default.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Oct 10 10:05:36 UTC 2017 - coolo@suse.com
+
+- Require X11 pattern (and together with GNOME also x11_enhanced), so
+  that deselecting GNOME will leave you with minimal X
+- 15.0.2
+
+-------------------------------------------------------------------
 Sun Oct 01 20:48:25 UTC 2017 - knut.anderssen@suse.com
 
 - Use the correct label and description from the former SLES role

--- a/package/system-role-server-default.spec
+++ b/package/system-role-server-default.spec
@@ -35,7 +35,7 @@ BuildRequires:  yast2-installation-control >= 4.0.0
 
 Url:            https://github.com/yast/system-role-server-default
 AutoReqProv:    off
-Version:        15.0.1
+Version:        15.0.2
 Release:        0
 Summary:        Server Normal role definition
 License:        MIT


### PR DESCRIPTION
so that deselecting GNOME pattern leaves you with minimal X